### PR TITLE
Fix extension dependency

### DIFF
--- a/fsh-generated/resources/Observation-mii-exa-labor-laborwert-range.json
+++ b/fsh-generated/resources/Observation-mii-exa-labor-laborwert-range.json
@@ -48,7 +48,7 @@
       {
         "code": "5787-7",
         "system": "http://loinc.org",
-        "display": "Epithelzellen [#/Fläche] in Urinsediment mittels Lichtmikroskopie, hohe Vergrösserung"
+        "display": "Epithelzellen [#/Fläche] in Urinsediment mittels Lichtmikroskopie, hohe Vergrößerung"
       }
     ],
     "text": "Urinsediment Epithelzellen Semi-quantitative Schätzung"

--- a/fsh-generated/resources/StructureDefinition-mii-pr-labor-laborbefund.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-labor-laborbefund.json
@@ -945,6 +945,20 @@
         "mustSupport": true
       },
       {
+        "id": "DiagnosticReport.effective[x].extension",
+        "path": "DiagnosticReport.effective[x].extension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "ordered": false,
+          "rules": "open"
+        }
+      },
+      {
         "id": "DiagnosticReport.effective[x].extension:QuelleKlinischesBezugsdatum",
         "path": "DiagnosticReport.effective[x].extension",
         "sliceName": "QuelleKlinischesBezugsdatum",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboruntersuchung.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboruntersuchung.json
@@ -137,6 +137,16 @@
       {
         "id": "Observation.modifierExtension",
         "path": "Observation.modifierExtension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "ordered": false,
+          "rules": "open"
+        },
         "mustSupport": true
       },
       {
@@ -951,6 +961,20 @@
         "mustSupport": true
       },
       {
+        "id": "Observation.effective[x].extension",
+        "path": "Observation.effective[x].extension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "ordered": false,
+          "rules": "open"
+        }
+      },
+      {
         "id": "Observation.effective[x].extension:QuelleKlinischesBezugsdatum",
         "path": "Observation.effective[x].extension",
         "sliceName": "QuelleKlinischesBezugsdatum",
@@ -1205,10 +1229,6 @@
           {
             "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
             "valueCode": "draft"
-          },
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version",
-            "valueCode": "4.0.0"
           }
         ],
         "path": "Observation.value[x].extension",
@@ -1231,15 +1251,25 @@
         "mustSupport": true
       },
       {
+        "id": "Observation.value[x]:valueQuantity.value.extension",
+        "path": "Observation.value[x].value.extension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "ordered": false,
+          "rules": "open"
+        }
+      },
+      {
         "id": "Observation.value[x]:valueQuantity.value.extension:quantityPrecision",
         "extension": [
           {
             "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
             "valueCode": "draft"
-          },
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version",
-            "valueCode": "4.0.0"
           }
         ],
         "path": "Observation.value[x].value.extension",

--- a/fsh-generated/resources/ValueSet-mii-vs-labor-identifier-type-codes.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-labor-identifier-type-codes.json
@@ -42,7 +42,7 @@
     "include": [
       {
         "valueSet": [
-          "http://hl7.org/fhir/ValueSet/identifier-type"
+          "http://hl7.org/fhir/ValueSet/identifier-type|4.0.1"
         ]
       },
       {

--- a/input/fsh/instances/mii-exa-labor-laborwert.fsh
+++ b/input/fsh/instances/mii-exa-labor-laborwert.fsh
@@ -66,7 +66,7 @@ Usage: #example
 * status = #final
 * category.coding[loinc-observation] = $loinc#26436-6 "Laboruntersuchungen"
 * category.coding[observation-category] = $observation-category#laboratory "Laboratory"
-* code = $loinc#5787-7 "Epithelzellen [#/Fläche] in Urinsediment mittels Lichtmikroskopie, hohe Vergrösserung"
+* code = $loinc#5787-7 "Epithelzellen [#/Fläche] in Urinsediment mittels Lichtmikroskopie, hohe Vergrößerung"
 * code.text = "Urinsediment Epithelzellen Semi-quantitative Schätzung"
 * subject.reference = "Patient/111"
 * encounter.reference = "Encounter/555"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "hl7.fhir.r4.core": "4.0.1",
     "de.medizininformatikinitiative.kerndatensatz.meta": "2026.0.0",
     "hl7.fhir.uv.ips": "2.0.0",
-    "hl7.fhir.uv.extensions": "5.2.0"
+    "hl7.fhir.uv.extensions.r4": "5.2.0"
   }
 }


### PR DESCRIPTION
This pull request introduces several updates to FHIR StructureDefinitions and ValueSets, mainly focusing on enhancing extension slicing for better conformance and updating dependency references. The most significant changes are the addition of open slicing to various extension elements in the `Observation` and `DiagnosticReport` resources, as well as updates to ValueSet and package dependency references.

**FHIR StructureDefinition improvements:**

**FHIR ValueSet and dependency updates:**

* Updated the `ValueSet-mii-vs-labor-identifier-type-codes.json` to reference a specific version (`4.0.1`) of the HL7 FHIR identifier type ValueSet, ensuring consistent terminology binding.
* Changed the dependency from `hl7.fhir.uv.extensions` to the R4-specific `hl7.fhir.uv.extensions.r4` in `package.json`, clarifying the intended FHIR version.