### PR TITLE
feat: add UML class diagram for Laborbefund module and update documentation

### DIFF
--- a/implementation-guides/ImplementationGuide-2027.x-DE/MIIIGModulLaborbefund/AnwendungsflleInformationsmodell/UML.page.md
+++ b/implementation-guides/ImplementationGuide-2027.x-DE/MIIIGModulLaborbefund/AnwendungsflleInformationsmodell/UML.page.md
@@ -4,6 +4,9 @@ topic: UML
 ### UML
 
 Als abstraktere Version eines Informationsmodells und zur besseren Verdeutlichung von Beziehungen der fachlichen Konzepte untereinander wurde ein UML-Klassendiagramm erstellt. In ART-DECOR als Gruppen abgebildete Konzepte werden als eigene Klassen modelliert, die hier Assoziationsbeziehungen zueinander haben. Ein Laborbefund ist hierbei assoziiert mit einem Patienten oder einer Patientin, einem Versorgungsfall, einer Gesundheitseinrichtung, untersuchtem Probenmaterial und der jeweiligen Laboruntersuchung. Solche Untersuchungen lassen sich in Bereich und Gruppen kategorisieren, enthalten spezifische Laborparameter und haben Referenzbereiche.
-Klassen, die auf Konzepten aus anderen Kerndatensatzmodulen beruhen, sind farblich von den Laborbefund-Klasssen abgehoben.
+Klassen, die auf Konzepten aus anderen Kerndatensatzmodulen beruhen, sind farblich von den Laborbefund-Klassen abgehoben.
 
-{{render:implementation-guides/ImplementationGuide-Common/images/UML_Laborbefund.png}}
+<figure>
+  {% include uml-laborbefund.svg %}
+  <figcaption>UML-Klassendiagramm des Moduls Laborbefund</figcaption>
+</figure>

--- a/input/images-source/uml-laborbefund.plantuml
+++ b/input/images-source/uml-laborbefund.plantuml
@@ -1,0 +1,98 @@
+@startuml UML_Laborbefund
+left to right direction
+hide empty methods
+skinparam classAttributeIconSize 0
+skinparam linetype ortho
+skinparam nodesep 45
+skinparam ranksep 55
+skinparam shadowing false
+
+!define LABOR #B3E5FC
+!define EXTERN #FCE4EC
+!define FALL #D5F5E3
+
+class "Patient:in" as Patient EXTERN
+class "Gesundheitseinrichtung" as Organisation EXTERN
+class "Einrichtungskontakt" as Kontakt FALL
+
+class Laborbefund LABOR {
+  + Identifikation: Identifier [1..*]
+  + Status: code [1]
+  + KlinischerBezugszeitpunkt: dateTime [1]
+  + Dokumentationsdatum: instant [1]
+}
+
+class Laboruntersuchung LABOR {
+  + Identifikation: Identifier [1..*]
+  + Status: code [1]
+  + KlinischerBezugszeitpunkt: dateTime [1]
+  + Dokumentationsdatum: instant [0..1]
+  + Ergebnis: value[x] [0..1]
+  + Interpretation: CodeableConcept [0..*]
+  + Kommentar: Annotation [0..*]
+  + Untersuchungsmethode: CodeableConcept [0..1]
+}
+
+class Probenmaterial LABOR {
+  + Identifikation: Identifier [0..*]
+  + Ent-/Abnahmezeitpunkt: dateTime | Period [0..1]
+  + Laboreingangszeitpunkt: dateTime [0..1]
+  + Probenart: CodeableConcept [0..1]
+  + Körperstelle: CodeableConcept [0..1]
+  + Kommentar: Annotation [0..*]
+}
+
+class Laboranforderung LABOR {
+  + Identifikation: Identifier [1..*]
+  + Status: code [1]
+  + Anforderungsdatum: dateTime [1]
+}
+
+class Bereich LABOR {
+  + Kode: code [1]
+  + Bezeichnung: string [0..1]
+}
+
+class Gruppe LABOR {
+  + Kode: code [1]
+  + Bezeichnung: string [0..1]
+}
+
+class Laborparameter LABOR {
+  + Kode: CodeableConcept [1]
+  + Bezeichnung: string [0..1]
+}
+
+class Referenzbereich LABOR {
+  + Typ: CodeableConcept [0..1]
+  + Obergrenze: SimpleQuantity [0..1]
+  + Untergrenze: SimpleQuantity [0..1]
+  + Text: string [0..1]
+}
+
+Patient "1" -right- "0..*" Laborbefund : subject
+Patient "1" -down- "0..*" Kontakt : subject
+Kontakt "0..1" -right- "0..*" Laborbefund : encounter
+Organisation "0..*" -right- "0..*" Laborbefund : performer
+
+Laborbefund "0..*" -down- "1..*" Laboranforderung : basedOn
+Laborbefund "0..*" -right- "1..*" Laboruntersuchung : result
+Laborbefund "0..*" -up- "0..*" Probenmaterial : specimen
+
+Laboranforderung "0..*" -up- "0..*" Probenmaterial : specimen
+Laboranforderung "0..*" -right- "1" Laborparameter : code
+
+Laboruntersuchung "0..*" -up- "0..1" Probenmaterial : specimen
+Laboruntersuchung "0..*" -down- "0..*" Bereich : category
+Bereich "1" o-right- "0..*" Gruppe : gliedert sich in
+Laboruntersuchung "0..*" -down- "0..*" Gruppe : category
+Laboruntersuchung "0..*" -right- "1" Laborparameter : code
+Laboruntersuchung "1" *-down- "0..*" Referenzbereich : referenceRange
+
+legend left
+  |= Farbe |= Herkunft |
+  | <back:LABOR>   </back> | Modul Laborbefund |
+  | <back:EXTERN>   </back> | Modul Person / Strukturdaten |
+  | <back:FALL>   </back> | Modul Falldaten |
+endlegend
+@enduml


### PR DESCRIPTION
This pull request updates the UML documentation for the Laborbefund module by introducing a new, more maintainable SVG-based UML class diagram and its PlantUML source. The new diagram improves clarity, theming, and integration with the documentation site.

**UML Diagram Improvements:**

* Added `uml-laborbefund.plantuml` as the PlantUML source for the UML class diagram, detailing classes, attributes, and relationships for the Laborbefund module, with color coding for module origins.
* Updated the UML documentation page (`UML.page.md`) to embed the new SVG diagram via `{% include uml-laborbefund.svg %}` and provide a caption, replacing the old static image.
* Fixed a typo in the documentation text (`Laborbefund-Klasssen` → `Laborbefund-Klassen`).