### PR TITLE
feat: vs expansions with fixed version

### DIFF
--- a/fsh-generated/resources/DiagnosticReport-mii-exa-labor-laborbefund.json
+++ b/fsh-generated/resources/DiagnosticReport-mii-exa-labor-laborbefund.json
@@ -39,6 +39,7 @@
         {
           "code": "26436-6",
           "system": "http://loinc.org",
+          "version": "2.82",
           "display": "Laboruntersuchungen"
         },
         {
@@ -53,6 +54,7 @@
       {
         "code": "11502-2",
         "system": "http://loinc.org",
+        "version": "2.82",
         "display": "Laborbericht"
       }
     ]

--- a/fsh-generated/resources/Observation-mii-exa-labor-laborwert-data-absent-reason.json
+++ b/fsh-generated/resources/Observation-mii-exa-labor-laborwert-data-absent-reason.json
@@ -39,6 +39,7 @@
         {
           "code": "26436-6",
           "system": "http://loinc.org",
+          "version": "2.82",
           "display": "Laboruntersuchungen"
         },
         {
@@ -59,6 +60,7 @@
       {
         "code": "59826-8",
         "system": "http://loinc.org",
+        "version": "2.82",
         "display": "Creatinin [Mol/Volumen] in Blut"
       }
     ],

--- a/fsh-generated/resources/Observation-mii-exa-labor-laborwert-range.json
+++ b/fsh-generated/resources/Observation-mii-exa-labor-laborwert-range.json
@@ -32,6 +32,7 @@
         {
           "code": "26436-6",
           "system": "http://loinc.org",
+          "version": "2.82",
           "display": "Laboruntersuchungen"
         },
         {
@@ -48,6 +49,7 @@
       {
         "code": "5787-7",
         "system": "http://loinc.org",
+        "version": "2.82",
         "display": "Epithelzellen [#/Fläche] in Urinsediment mittels Lichtmikroskopie, hohe Vergrößerung"
       }
     ],

--- a/fsh-generated/resources/Observation-mii-exa-labor-laborwert-ratio.json
+++ b/fsh-generated/resources/Observation-mii-exa-labor-laborwert-ratio.json
@@ -32,6 +32,7 @@
         {
           "code": "26436-6",
           "system": "http://loinc.org",
+          "version": "2.82",
           "display": "Laboruntersuchungen"
         },
         {
@@ -48,6 +49,7 @@
       {
         "code": "1755-8",
         "system": "http://loinc.org",
+        "version": "2.82",
         "display": "Albumin [Masse/Zeit] in 24-Stunden-Sammelurin"
       }
     ],

--- a/fsh-generated/resources/Observation-mii-exa-labor-laborwert.json
+++ b/fsh-generated/resources/Observation-mii-exa-labor-laborwert.json
@@ -39,6 +39,7 @@
         {
           "code": "26436-6",
           "system": "http://loinc.org",
+          "version": "2.82",
           "display": "Laboruntersuchungen"
         },
         {
@@ -95,6 +96,7 @@
       {
         "code": "59826-8",
         "system": "http://loinc.org",
+        "version": "2.82",
         "display": "Creatinin [Mol/Volumen] in Blut"
       }
     ],

--- a/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboruntersuchung.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboruntersuchung.json
@@ -1399,7 +1399,7 @@
         ],
         "mustSupport": true,
         "binding": {
-          "strength": "required",
+          "strength": "extensible",
           "valueSet": "https://www.medizininformatik-initiative.de/fhir/core/modul-labor/ValueSet/Laborergebnis-codiert"
         }
       },

--- a/fsh-generated/resources/ValueSet-mii-vs-labor-laborbereich.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-labor-laborbereich.json
@@ -43,6 +43,7 @@
     "include": [
       {
         "system": "http://loinc.org",
+        "version": "2.82",
         "concept": [
           {
             "code": "18717-9",

--- a/fsh-generated/resources/ValueSet-mii-vs-labor-order-codes.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-labor-order-codes.json
@@ -43,6 +43,7 @@
     "include": [
       {
         "system": "http://loinc.org",
+        "version": "2.82",
         "filter": [
           {
             "property": "ORDER_OBS",

--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -1,5 +1,9 @@
+// Versionsgebundene Aliase: für ValueSet-Kompositionen und Instanzen
 Alias: $sct = http://snomed.info/sct|http://snomed.info/sct/900000000000207008/version/20250701
-Alias: $loinc = http://loinc.org
+Alias: $loinc = http://loinc.org|2.82
+// Versionslose Aliase: ausschließlich für Patterns/fixed values in Profilen
+Alias: $sct-pattern = http://snomed.info/sct
+Alias: $loinc-pattern = http://loinc.org
 Alias: $v2-0074 = http://terminology.hl7.org/CodeSystem/v2-0074
 Alias: $v2-0203 = http://terminology.hl7.org/CodeSystem/v2-0203
 Alias: $observation-category = http://terminology.hl7.org/CodeSystem/observation-category

--- a/input/fsh/profiles/MII_PR_Labor_Laborbefund.fsh
+++ b/input/fsh/profiles/MII_PR_Labor_Laborbefund.fsh
@@ -78,7 +78,7 @@ Description: "Dieses Profil beschreibt einen Laborbefund in der Medizininformati
 * category.coding contains
     loinc-lab 1..1 MS and
     diagnostic-service-sections 1..1 MS
-* category.coding[loinc-lab] = $loinc#26436-6
+* category.coding[loinc-lab] = $loinc-pattern#26436-6
 * category.coding[diagnostic-service-sections] = $v2-0074#LAB
 * code MS
   * ^short = "Code"
@@ -95,7 +95,7 @@ Description: "Dieses Profil beschreibt einen Laborbefund in der Medizininformati
 * code.coding ^slicing.discriminator.path = "$this"
 * code.coding ^slicing.rules = #open
 * code.coding contains loinc-labReport 1..1 MS
-* code.coding[loinc-labReport] = $loinc#11502-2
+* code.coding[loinc-labReport] = $loinc-pattern#11502-2
 * subject 1.. MS
   * reference MS
   * identifier MS

--- a/input/fsh/profiles/MII_PR_Labor_Laboruntersuchung.fsh
+++ b/input/fsh/profiles/MII_PR_Labor_Laboruntersuchung.fsh
@@ -91,7 +91,7 @@ Description: "Dieses Profil beschreibt eine Laborergebnis in der Medizininformat
 * category.coding contains
     loinc-observation 1..1 MS and
     observation-category 1..1 MS
-* category.coding[loinc-observation] = $loinc#26436-6
+* category.coding[loinc-observation] = $loinc-pattern#26436-6
 * category.coding[observation-category] = $observation-category#laboratory
 * code MS
   * ^short = "Code"


### PR DESCRIPTION
Umgesetzt laut: https://github.com/medizininformatik-initiative/kerndatensatz-meta/wiki/Terminology-Version-Policy#additional-note-on-instance-level-coding

This pull request updates LOINC code system references throughout the project to consistently use version 2.82, and introduces a distinction between versioned and unversioned aliases for LOINC and SNOMED CT. It also adjusts terminology bindings and the use of aliases in FSH profiles to improve clarity and maintainability.

**Terminology Versioning and Aliases**

* Updated the `$loinc` alias to include version 2.82 and introduced `$loinc-pattern` for unversioned references in `aliases.fsh`. Similarly, added `$sct-pattern` for SNOMED CT. This ensures that ValueSet compositions and instances use versioned URLs, while profiles can use unversioned URLs for patterns and fixed values.
* Updated FSH profiles (`MII_PR_Labor_Laborbefund.fsh`, `MII_PR_Labor_Laboruntersuchung.fsh`) to use `$loinc-pattern` instead of `$loinc` when specifying fixed values for LOINC codes, aligning with the new alias strategy. [[1]](diffhunk://#diff-3f20380d323d4f578bff92685dcc63870cf670de8ef07a19b634b522794e5966L81-R81) [[2]](diffhunk://#diff-3f20380d323d4f578bff92685dcc63870cf670de8ef07a19b634b522794e5966L98-R98) [[3]](diffhunk://#diff-b8a521854261222358720fd2616ad8fbc6119c914c6a27a0bfbf1cb465a9d6d1L94-R94)

**Resource and ValueSet Updates**

* Added `"version": "2.82"` to all relevant LOINC code references in generated resource JSON files, ensuring consistent use of the correct code system version across `DiagnosticReport`, `Observation`, and `ValueSet` resources. [[1]](diffhunk://#diff-a615f0029f6d7786d4e28594c2a42a0f1b0eb7b1c0084188122070b2d5bbba5eR42) [[2]](diffhunk://#diff-a615f0029f6d7786d4e28594c2a42a0f1b0eb7b1c0084188122070b2d5bbba5eR57) [[3]](diffhunk://#diff-b5d3899c9c560b897e8ed9fc769b320a9e7affd1404c6955290b5571ed2a007bR42) [[4]](diffhunk://#diff-b5d3899c9c560b897e8ed9fc769b320a9e7affd1404c6955290b5571ed2a007bR63) [[5]](diffhunk://#diff-4fd7f78f10ffff5d88fdbdda534020bff2a96daf0b73bc3932ff1844d3e93bb6R35) [[6]](diffhunk://#diff-4fd7f78f10ffff5d88fdbdda534020bff2a96daf0b73bc3932ff1844d3e93bb6R52) [[7]](diffhunk://#diff-b7260a672d898da13129ba359cc7e1d303bdc3e4ec477fe693db8c4051453e54R35) [[8]](diffhunk://#diff-b7260a672d898da13129ba359cc7e1d303bdc3e4ec477fe693db8c4051453e54R52) [[9]](diffhunk://#diff-56575e2338f803cb1b1913ddacf6582337f7c637ba9a8247873ac3682af5976aR42) [[10]](diffhunk://#diff-56575e2338f803cb1b1913ddacf6582337f7c637ba9a8247873ac3682af5976aR99) [[11]](diffhunk://#diff-956fb46201acfe4b62491e476c4f60b556f0b1b3be17ff54d0824cecf18ee950R46) [[12]](diffhunk://#diff-933ab3d785eef24363bfc2ec9d9f0def8f61a49713ce0d797b0316d9481263bfR46)

**Terminology Binding Adjustment**

* Changed the binding strength for the `Laborergebnis-codiert` ValueSet in the `StructureDefinition-mii-pr-labor-laboruntersuchung.json` from `required` to `extensible`, allowing for greater flexibility in coding.