### PR TITLE
fix: invariant expression mii-lab-2

### DIFF
--- a/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboruntersuchung.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboruntersuchung.json
@@ -109,7 +109,7 @@
             "key": "mii-lab-2",
             "severity": "error",
             "human": "Falls kein Laborwert verfügbar ist, muss eine dataAbsentReason angegeben werden",
-            "expression": "hasMember.exists() xor (value.exists() or dataAbsentReason.exists())",
+            "expression": "hasMember.exists() or value.exists() or dataAbsentReason.exists()",
             "source": "https://www.medizininformatik-initiative.de/fhir/core/modul-labor/StructureDefinition/ObservationLab"
           }
         ]

--- a/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboruntersuchung.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboruntersuchung.json
@@ -109,7 +109,7 @@
             "key": "mii-lab-2",
             "severity": "error",
             "human": "Falls kein Laborwert verfügbar ist, muss eine dataAbsentReason angegeben werden",
-            "expression": "hasMember.exists() xor value.exists().not() implies dataAbsentReason.exists()",
+            "expression": "hasMember.exists() xor (value.exists() or dataAbsentReason.exists())",
             "source": "https://www.medizininformatik-initiative.de/fhir/core/modul-labor/StructureDefinition/ObservationLab"
           }
         ]
@@ -1399,7 +1399,7 @@
         ],
         "mustSupport": true,
         "binding": {
-          "strength": "required",
+          "strength": "extensible",
           "valueSet": "https://www.medizininformatik-initiative.de/fhir/core/modul-labor/ValueSet/Laborergebnis-codiert"
         }
       },

--- a/input/fsh/invariants/mii-lab-2.fsh
+++ b/input/fsh/invariants/mii-lab-2.fsh
@@ -1,4 +1,4 @@
 Invariant: mii-lab-2
 Description: "Falls kein Laborwert verfügbar ist, muss eine dataAbsentReason angegeben werden"
 Severity: #error
-Expression: "hasMember.exists() xor value.exists().not() implies dataAbsentReason.exists()"
+Expression: "hasMember.exists() xor (value.exists() or dataAbsentReason.exists())"

--- a/input/fsh/invariants/mii-lab-2.fsh
+++ b/input/fsh/invariants/mii-lab-2.fsh
@@ -1,4 +1,4 @@
 Invariant: mii-lab-2
 Description: "Falls kein Laborwert verfügbar ist, muss eine dataAbsentReason angegeben werden"
 Severity: #error
-Expression: "hasMember.exists() xor (value.exists() or dataAbsentReason.exists())"
+Expression: "hasMember.exists() or value.exists() or dataAbsentReason.exists()"


### PR DESCRIPTION
This pull request updates the logic and binding strength for the `mii-lab-2` invariant and associated ValueSet binding in the laboratory observation profile. The main focus is to clarify the validation rule for handling absent laboratory values and to relax the strictness of a ValueSet binding.

Validation logic improvements:

* Updated the `mii-lab-2` invariant expression in both the FHIR JSON profile (`StructureDefinition-mii-pr-labor-laboruntersuchung.json`) and its FSH definition (`mii-lab-2.fsh`) to correctly require a `dataAbsentReason` only when neither a value nor a `hasMember` is present. This makes the rule more precise and reduces false validation errors. [[1]](diffhunk://#diff-a88bf71ffafc927b251859577d18506539b9d575f4f856d19d4abf65fe6a5a0cL112-R112) [[2]](diffhunk://#diff-daee17c1ff5f6715d4d513f5dec05ca70d2aedaf455ffd3f65e174abdfc11602L4-R4)

Terminology binding update:

* Changed the binding strength for the `Laborergebnis-codiert` ValueSet from `required` to `extensible` in the FHIR JSON profile, allowing for more flexibility in coding laboratory results.