### PR TITLE
feat: add 'version' MS to coding elements in ServiceRequest and Obser…

### DIFF
--- a/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboranforderung.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboranforderung.json
@@ -670,6 +670,11 @@
         "mustSupport": true
       },
       {
+        "id": "ServiceRequest.code.coding.version",
+        "path": "ServiceRequest.code.coding.version",
+        "mustSupport": true
+      },
+      {
         "id": "ServiceRequest.code.coding.code",
         "path": "ServiceRequest.code.coding.code",
         "min": 1,

--- a/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboruntersuchung.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboruntersuchung.json
@@ -788,6 +788,11 @@
         "mustSupport": true
       },
       {
+        "id": "Observation.code.coding.version",
+        "path": "Observation.code.coding.version",
+        "mustSupport": true
+      },
+      {
         "id": "Observation.code.coding.code",
         "path": "Observation.code.coding.code",
         "min": 1,
@@ -1399,7 +1404,7 @@
         ],
         "mustSupport": true,
         "binding": {
-          "strength": "required",
+          "strength": "extensible",
           "valueSet": "https://www.medizininformatik-initiative.de/fhir/core/modul-labor/ValueSet/Laborergebnis-codiert"
         }
       },
@@ -1413,6 +1418,11 @@
         "id": "Observation.value[x]:valueCodeableConcept.coding.system",
         "path": "Observation.value[x].coding.system",
         "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.value[x]:valueCodeableConcept.coding.version",
+        "path": "Observation.value[x].coding.version",
         "mustSupport": true
       },
       {

--- a/input/fsh/profiles/MII_PR_Labor_Laboranforderung.fsh
+++ b/input/fsh/profiles/MII_PR_Labor_Laboranforderung.fsh
@@ -90,6 +90,7 @@ Description: "Dieses Profil beschreibt eine Laboranforderung in der Medizininfor
 * code from mii-vs-labor-order-codes (example)
   * coding MS
     * system 1.. MS
+    * version MS
     * code 1.. MS
     * display MS
 * subject 1.. MS

--- a/input/fsh/profiles/MII_PR_Labor_Laboruntersuchung.fsh
+++ b/input/fsh/profiles/MII_PR_Labor_Laboruntersuchung.fsh
@@ -98,6 +98,7 @@ Description: "Dieses Profil beschreibt eine Laborergebnis in der Medizininformat
   * ^definition = "LOINC-Code, der den gemessenen Laborparameter bzw. durchgeführten Labortest beschreibt."
   * coding MS
     * system 1.. MS
+    * version MS
     * code 1.. MS
     * display MS
 * insert Translation(code ^short, de-DE, Code)
@@ -174,6 +175,7 @@ Description: "Dieses Profil beschreibt eine Laborergebnis in der Medizininformat
 * valueCodeableConcept from MII_VS_Labor_Laborergebnis_Codiert (extensible)
 * valueCodeableConcept.coding 1.. MS
 * valueCodeableConcept.coding.system 1.. MS
+* valueCodeableConcept.coding.version MS
 * valueCodeableConcept.coding.code 1.. MS
 * valueRange MS
 * valueRatio MS


### PR DESCRIPTION
This pull request updates the MII laboratory FHIR profiles to add explicit support for the `version` element in coding structures and refines value set binding strength for coded laboratory results. These changes improve interoperability and data precision by ensuring that coding versions are consistently captured and by allowing more flexibility in the coding of laboratory results.

**Support for coding version fields:**
- Added `version` as a must-support field to `code.coding` in the `ServiceRequest` profile (`MII_PR_Labor_Laboranforderung`) to ensure the version of the coding system is captured. [[1]](diffhunk://#diff-78cdeed523a98833bd0ae5635c01edf5195402d22d3aae586e5920a118582ea6R93) [[2]](diffhunk://#diff-b56a72882e08253e9aeaf78e907846ef69dd08635815e1e3c3d524467b5bdc87R672-R676)
- Added `version` as a must-support field to `Observation.code.coding` and `Observation.valueCodeableConcept.coding` in the `Observation` profile (`MII_PR_Labor_Laboruntersuchung`) for improved traceability of code versions. [[1]](diffhunk://#diff-b8a521854261222358720fd2616ad8fbc6119c914c6a27a0bfbf1cb465a9d6d1R101) [[2]](diffhunk://#diff-a88bf71ffafc927b251859577d18506539b9d575f4f856d19d4abf65fe6a5a0cR790-R794) [[3]](diffhunk://#diff-b8a521854261222358720fd2616ad8fbc6119c914c6a27a0bfbf1cb465a9d6d1R178) [[4]](diffhunk://#diff-a88bf71ffafc927b251859577d18506539b9d575f4f856d19d4abf65fe6a5a0cR1423-R1427)

**Value set binding refinement:**
- Changed the binding strength for `Observation.valueCodeableConcept` from `required` to `extensible` to allow for additional codes beyond those in the specified value set, increasing flexibility in coding laboratory results.