### PR TITLE
feat: Observation.interpretation auf kuratiertes ValueSet einschränken

### DIFF
--- a/fsh-generated/resources/StructureDefinition-mii-pr-labor-laborbefund.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-labor-laborbefund.json
@@ -1087,20 +1087,6 @@
         "mustSupport": true
       },
       {
-        "id": "DiagnosticReport.effective[x].extension",
-        "path": "DiagnosticReport.effective[x].extension",
-        "slicing": {
-          "discriminator": [
-            {
-              "type": "value",
-              "path": "url"
-            }
-          ],
-          "ordered": false,
-          "rules": "open"
-        }
-      },
-      {
         "id": "DiagnosticReport.effective[x].extension:QuelleKlinischesBezugsdatum",
         "path": "DiagnosticReport.effective[x].extension",
         "sliceName": "QuelleKlinischesBezugsdatum",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboruntersuchung.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboruntersuchung.json
@@ -1768,7 +1768,42 @@
             }
           ]
         },
-        "mustSupport": true
+        "mustSupport": true,
+        "binding": {
+          "strength": "extensible",
+          "valueSet": "https://www.medizininformatik-initiative.de/fhir/core/modul-labor/ValueSet/Interpretation",
+          "description": "Eingeschränkte Auswahl aus HL7 v3 ObservationInterpretation. Lokal gebräuchliche Skalen wie -- - N + ++ bzw. L N H bilden auf diese Konzepte ab. Die Bindung ist extensible: für Werte jenseits der Telefongrenze können zusätzlich die abnormal-Codes HH, LL und AA verwendet werden.",
+          "_description": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                  {
+                    "url": "lang",
+                    "valueCode": "de-DE"
+                  },
+                  {
+                    "url": "content",
+                    "valueString": "Eingeschränkte Auswahl aus HL7 v3 ObservationInterpretation. Lokal gebräuchliche Skalen wie -- - N + ++ bzw. L N H bilden auf diese Konzepte ab. Die Bindung ist extensible: für Werte jenseits der Telefongrenze können zusätzlich die abnormal-Codes HH, LL und AA verwendet werden."
+                  }
+                ]
+              },
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                  {
+                    "url": "lang",
+                    "valueCode": "en-US"
+                  },
+                  {
+                    "url": "content",
+                    "valueString": "Restricted selection from HL7 v3 ObservationInterpretation. Locally used scales such as -- - N + ++ or L N H map onto these concepts. The binding is extensible: for values beyond the critical notification limit the abnormal codes HH, LL and AA may additionally be used."
+                  }
+                ]
+              }
+            ]
+          }
+        }
       },
       {
         "id": "Observation.note",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboruntersuchung.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboruntersuchung.json
@@ -296,16 +296,6 @@
       {
         "id": "Observation.modifierExtension",
         "path": "Observation.modifierExtension",
-        "slicing": {
-          "discriminator": [
-            {
-              "type": "value",
-              "path": "url"
-            }
-          ],
-          "ordered": false,
-          "rules": "open"
-        },
         "mustSupport": true
       },
       {
@@ -1220,20 +1210,6 @@
         "mustSupport": true
       },
       {
-        "id": "Observation.effective[x].extension",
-        "path": "Observation.effective[x].extension",
-        "slicing": {
-          "discriminator": [
-            {
-              "type": "value",
-              "path": "url"
-            }
-          ],
-          "ordered": false,
-          "rules": "open"
-        }
-      },
-      {
         "id": "Observation.effective[x].extension:QuelleKlinischesBezugsdatum",
         "path": "Observation.effective[x].extension",
         "sliceName": "QuelleKlinischesBezugsdatum",
@@ -1508,20 +1484,6 @@
         "path": "Observation.value[x].value",
         "min": 1,
         "mustSupport": true
-      },
-      {
-        "id": "Observation.value[x]:valueQuantity.value.extension",
-        "path": "Observation.value[x].value.extension",
-        "slicing": {
-          "discriminator": [
-            {
-              "type": "value",
-              "path": "url"
-            }
-          ],
-          "ordered": false,
-          "rules": "open"
-        }
       },
       {
         "id": "Observation.value[x]:valueQuantity.value.extension:quantityPrecision",

--- a/fsh-generated/resources/ValueSet-mii-vs-labor-interpretation.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-labor-interpretation.json
@@ -1,0 +1,212 @@
+{
+  "resourceType": "ValueSet",
+  "status": "active",
+  "name": "MII_VS_Labor_Interpretation",
+  "id": "mii-vs-labor-interpretation",
+  "title": "MII VS Labor Interpretation",
+  "description": "Kategorische Bewertung eines Laborwertes. Eingeschränkte Auswahl aus HL7 v3 ObservationInterpretation auf die im Laborkontext sinnvollen Konzepte.",
+  "url": "https://www.medizininformatik-initiative.de/fhir/core/modul-labor/ValueSet/Interpretation",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset",
+      "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset",
+      "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset",
+      "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+    ],
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/package-source",
+        "extension": [
+          {
+            "url": "packageId",
+            "valueId": "de.medizininformatikinitiative.kerndatensatz.labor"
+          },
+          {
+            "url": "version",
+            "valueString": "2027.0.0"
+          },
+          {
+            "url": "uri",
+            "valueUri": "https://www.medizininformatik-initiative.de/fhir/core/modul-labor"
+          }
+        ]
+      }
+    ]
+  },
+  "version": "2027.0.0",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-versionAlgorithm",
+      "valueCoding": {
+        "code": "semver",
+        "system": "http://hl7.org/fhir/version-algorithm",
+        "display": "SemVer"
+      }
+    },
+    {
+      "url": "https://www.medizininformatik-initiative.de/fhir/modul-meta/StructureDefinition/mii-ex-meta-license-codeable",
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "code": "CC-BY-4.0",
+            "system": "http://hl7.org/fhir/spdx-license",
+            "display": "Creative Commons Attribution 4.0 International"
+          }
+        ]
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/cqf-knowledgeCapability",
+      "valueCode": "shareable"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/cqf-knowledgeCapability",
+      "valueCode": "publishable"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/cqf-knowledgeCapability",
+      "valueCode": "computable"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-versionPolicy",
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "code": "package",
+            "system": "http://terminology.hl7.org/CodeSystem/artifact-version-policy-codes",
+            "display": "Package"
+          }
+        ]
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-topic",
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "code": "C36292",
+            "system": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl"
+          }
+        ]
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-topic",
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "code": "C25294",
+            "system": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl"
+          }
+        ]
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-author",
+      "valueContactDetail": {
+        "telecom": [
+          {
+            "system": "email",
+            "value": "pw@gefyra.de"
+          }
+        ]
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-editor",
+      "valueContactDetail": {
+        "name": "Taskforce Core Data Set"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-reviewer",
+      "valueContactDetail": {
+        "name": "Interoperability Working Group",
+        "telecom": [
+          {
+            "system": "url",
+            "value": "https://www.medizininformatik-initiative.de/en/collaboration/interoperability-working-group"
+          }
+        ]
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-reviewer",
+      "valueContactDetail": {
+        "name": "National Steering Committee",
+        "telecom": [
+          {
+            "system": "url",
+            "value": "https://www.medizininformatik-initiative.de/en/collaboration/national-steering-committee"
+          }
+        ]
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-endorser",
+      "valueContactDetail": {
+        "name": "Interoperability Working Group",
+        "telecom": [
+          {
+            "system": "url",
+            "value": "https://www.medizininformatik-initiative.de/en/collaboration/interoperability-working-group"
+          }
+        ]
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-endorser",
+      "valueContactDetail": {
+        "name": "National Steering Committee",
+        "telecom": [
+          {
+            "system": "url",
+            "value": "https://www.medizininformatik-initiative.de/en/collaboration/national-steering-committee"
+          }
+        ]
+      }
+    }
+  ],
+  "publisher": "Medizininformatik Initiative",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "https://www.medizininformatik-initiative.de"
+        }
+      ]
+    }
+  ],
+  "experimental": false,
+  "date": "2026-08-28",
+  "compose": {
+    "include": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+        "concept": [
+          {
+            "code": "L",
+            "display": "Low"
+          },
+          {
+            "code": "LU",
+            "display": "Significantly low"
+          },
+          {
+            "code": "N",
+            "display": "Normal"
+          },
+          {
+            "code": "H",
+            "display": "High"
+          },
+          {
+            "code": "HU",
+            "display": "Significantly high"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/input/fsh/profiles/MII_PR_Labor_Laboruntersuchung.fsh
+++ b/input/fsh/profiles/MII_PR_Labor_Laboruntersuchung.fsh
@@ -211,6 +211,10 @@ Description: "Dieses Profil beschreibt eine Laborergebnis in der Medizininformat
 * insert Translation(interpretation ^short, en-US, Interpretation)
 * insert Translation(interpretation ^definition, de-DE, [[Eine kategorische Bewertung des Messwertes. Zum Beispiel hoch, niedrig, normal.]])
 * insert Translation(interpretation ^definition, en-US, [[A categorical assessment of the value. For example, high, low, normal.]])
+* interpretation from mii-vs-labor-interpretation (extensible)
+* interpretation ^binding.description = "Eingeschränkte Auswahl aus HL7 v3 ObservationInterpretation. Lokal gebräuchliche Skalen wie -- - N + ++ bzw. L N H bilden auf diese Konzepte ab. Die Bindung ist extensible: für Werte jenseits der Telefongrenze können zusätzlich die abnormal-Codes HH, LL und AA verwendet werden."
+* insert Translation(interpretation ^binding.description, de-DE, [[Eingeschränkte Auswahl aus HL7 v3 ObservationInterpretation. Lokal gebräuchliche Skalen wie -- - N + ++ bzw. L N H bilden auf diese Konzepte ab. Die Bindung ist extensible: für Werte jenseits der Telefongrenze können zusätzlich die abnormal-Codes HH, LL und AA verwendet werden.]])
+* insert Translation(interpretation ^binding.description, en-US, [[Restricted selection from HL7 v3 ObservationInterpretation. Locally used scales such as -- - N + ++ or L N H map onto these concepts. The binding is extensible: for values beyond the critical notification limit the abnormal codes HH, LL and AA may additionally be used.]])
 * note MS
   * ^short = "Hinweis"
   * ^definition = "Zusätzliche Informationen zur Laboruntersuchung als Freitext."

--- a/input/fsh/valuesets/MII_VS_Labor_Interpretation.fsh
+++ b/input/fsh/valuesets/MII_VS_Labor_Interpretation.fsh
@@ -1,0 +1,30 @@
+ValueSet: MII_VS_Labor_Interpretation
+Id: mii-vs-labor-interpretation
+Title: "MII VS Labor Interpretation"
+Description: "Kategorische Bewertung eines Laborwertes. Eingeschränkte Auswahl aus HL7 v3 ObservationInterpretation auf die im Laborkontext sinnvollen Konzepte."
+* ^meta.profile = "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
+* ^url = "https://www.medizininformatik-initiative.de/fhir/core/modul-labor/ValueSet/Interpretation"
+* insert PR_CS_VS_Version
+* insert Publisher
+* insert LicenseCodeableCCBY40
+* insert CRMIShareableValueSet
+* insert CRMIPublishableValueSet
+* insert CRMIComputableValueSet
+* insert CRMIKnowledgeCapabilitiesValueSet
+* insert CRMIVersionPolicyStrict
+* insert CRMIPackageSourceDefinitionalResource
+* insert CRMIArtifactTopic(http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl, C36292)
+* insert CRMIArtifactTopic(http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl, C25294)
+* insert CRMIArtifactContributors
+* ^status = #active
+* ^experimental = false
+* ^date = "2026-08-28"
+// Lokal gebraeuchliche Skalen wie "--, -, N, +, ++" bzw. "L N H" bilden auf
+// diese fuenf Konzepte ab (Issue #81). Die Bindung ist extensible: fuer
+// Befunde jenseits der Telefongrenze koennen zusaetzlich die abnormal-Codes
+// des CodeSystems verwendet werden (HH, LL, AA).
+* $v3-ObservationInterpretation#L "Low"
+* $v3-ObservationInterpretation#LU "Significantly low"
+* $v3-ObservationInterpretation#N "Normal"
+* $v3-ObservationInterpretation#H "High"
+* $v3-ObservationInterpretation#HU "Significantly high"

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -8,6 +8,7 @@ Changes since 2026.0.3:
 - `Observation.valueCodeableConcept` is bound (extensible) to the new ValueSet [Coded laboratory results](ValueSet-mii-vs-labor-laborergebnis-codiert.html), which unions the qualitative and semiquantitative result ValueSets. The previously planned `qualitativ`/`semiquantitativ` slices were dropped because the two ValueSets overlap and could not be discriminated.
 - `Observation.code.coding` gains an open `loinc` slice with an extensible binding to the IPS laboratory results ValueSet.
 - `Coding.version` is flagged Must Support on `Observation.code`, `Observation.valueCodeableConcept` and `ServiceRequest.code`.
+- `Observation.interpretation` is bound (extensible) to the new ValueSet [Interpretation](ValueSet-mii-vs-labor-interpretation.html), a restricted selection from HL7 v3 ObservationInterpretation (`L`, `LU`, `N`, `H`, `HU`). Locally used scales map onto these concepts; beyond the critical notification limit the abnormal codes `HH`, `LL` and `AA` may additionally be used.
 
 ## 2026.0.3
 

--- a/input/pagecontent/terminology.md
+++ b/input/pagecontent/terminology.md
@@ -39,5 +39,6 @@ The following module-specific ValueSets are published without an embedded expans
 - [Order codes](ValueSet-mii-vs-labor-order-codes.html)
 - [Qualitative laboratory results](ValueSet-mii-vs-labor-laborergebnis-qualitativ.html)
 - [Coded laboratory results](ValueSet-mii-vs-labor-laborergebnis-codiert.html)
+- [Interpretation](ValueSet-mii-vs-labor-interpretation.html)
 - [Interpretation-affecting properties](ValueSet-mii-vs-labor-interpretation-eigenschaften-snomedct.html)
 - [Identifier types](ValueSet-mii-vs-labor-identifier-type-codes.html)

--- a/input/translations/de/pagecontent/changes.md
+++ b/input/translations/de/pagecontent/changes.md
@@ -13,6 +13,7 @@ Die Version 2027.0.0 enthält im Vergleich zur Vorversion 2026.0.3 folgende Änd
 - valueCodeableConcept: Extensible-Binding an das neue ValueSet [Laborergebnis codiert](ValueSet-mii-vs-labor-laborergebnis-codiert.html), welches die qualitativen und semiquantitativen Ergebnis-ValueSets zusammenfasst. Die zunächst vorgesehenen Slices `qualitativ` und `semiquantitativ` entfallen, da sich beide ValueSets überschneiden und daher nicht diskriminiert werden können.
 - code.coding: Neuer offener Slice `loinc` mit Extensible-Binding an das IPS-ValueSet der Laborergebnisse.
 - `Coding.version` ist auf `Observation.code`, `Observation.valueCodeableConcept` und `ServiceRequest.code` als Must Support markiert.
+- interpretation: Extensible-Binding an das neue ValueSet [Interpretation](ValueSet-mii-vs-labor-interpretation.html), eine eingeschränkte Auswahl aus HL7 v3 ObservationInterpretation (`L`, `LU`, `N`, `H`, `HU`). Lokal gebräuchliche Skalen wie `--, -, N, +, ++` bzw. `L N H` bilden darauf ab; jenseits der Telefongrenze können zusätzlich die abnormal-Codes `HH`, `LL` und `AA` verwendet werden.
 
 ### Version: 2026.0.3
 Die Version 2026.0.3 enthält im Vergleich zur Vorversion 2026.0.2 folgende Änderungen (für einen vollständigen Überblick über die Änderungen kann der [Differential-View auf Github](https://github.com/medizininformatik-initiative/kerndatensatzmodul-labor/compare/2026.0.2...2026.0.3) verwendet werden).

--- a/input/translations/de/pagecontent/terminology.md
+++ b/input/translations/de/pagecontent/terminology.md
@@ -59,6 +59,12 @@ Canoncial: ```https://www.medizininformatik-initiative.de/fhir/core/modul-labor/
 
 -----
 
+Canoncial: ```https://www.medizininformatik-initiative.de/fhir/core/modul-labor/ValueSet/Interpretation```
+
+[ValueSet Interpretation](ValueSet-mii-vs-labor-interpretation.html)
+
+-----
+
 Canoncial: ```https://www.medizininformatik-initiative.de/fhir/core/modul-labor/ValueSet/QuelleKlinischesBezugsdatum```
 
 [ValueSet Quelle Klinisches Bezugsdatum](ValueSet-mii-vs-labor-quelle-klinisches-bezugsdatum.html)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -205,6 +205,7 @@ parameters:
     - https://www.medizininformatik-initiative.de/fhir/core/modul-labor/ValueSet/Laborergebnis-semiquantitativ
     - https://www.medizininformatik-initiative.de/fhir/core/modul-labor/ValueSet/Laborergebnis-qualitativ
     - https://www.medizininformatik-initiative.de/fhir/core/modul-labor/ValueSet/Laborergebnis-codiert
+    - https://www.medizininformatik-initiative.de/fhir/core/modul-labor/ValueSet/Interpretation
     - https://www.medizininformatik-initiative.de/fhir/core/modul-labor/ValueSet/ValueSetOrderCodes
     - https://www.medizininformatik-initiative.de/fhir/core/modul-labor/ValueSet/QuelleKlinischesBezugsdatum
   path-resource:


### PR DESCRIPTION
Closes #81.

## Was sich ändert

Neues ValueSet **`MII_VS_Labor_Interpretation`** (`…/ValueSet/Interpretation`) als Subset von HL7 v3 ObservationInterpretation mit den im Laborkontext sinnvollen Konzepten:

| Code | Display |
|---|---|
| `L` | Low |
| `LU` | Significantly low |
| `N` | Normal |
| `H` | High |
| `HU` | Significantly high |

`Observation.interpretation` ist **extensible** daran gebunden.

## Hinweis zur Telefongrenze

Lokal gebräuchliche Skalen (`--, -, N, +, ++` bzw. `L N H`) bilden auf diese fünf Konzepte ab. Die Bindung bleibt bewusst extensible, damit für Werte jenseits der Telefongrenze zusätzlich die abnormal-Codes `HH`, `LL` und `AA` verwendet werden können. Der Hinweis steht maschinenlesbar in `binding.description`, zweisprachig (de-DE / en-US) wie die übrige Elementdokumentation.

## Entscheidung zur Diskussion

Der Issue-Kommentar nennt als Wertemenge `L, LU, N, H, HU` und die abnormal-Codes separat als *Hinweis*. Ich habe das wörtlich umgesetzt — **`HH`, `LL` und `AA` sind nicht im ValueSet**, sondern nur im Hinweistext. Falls die Telefongrenze als MII-Regelfall gilt und die Codes hineingehören, sind es zwei Zeilen.

## Sonstiges

- Terminologie-Seite und Changelog in beiden Sprachbäumen ergänzt
- Canonical in `special-url` registriert (Terminal-Segment ≠ Id)
- Alle fünf Codes gegen `hl7.terminology.r4#7.3.0` verifiziert
- SUSHI 3.20.0: 0 Errors, 0 Warnings